### PR TITLE
feat: create with durations

### DIFF
--- a/programs/lockup/src/instructions/stream_creation/create_with_durations.rs
+++ b/programs/lockup/src/instructions/stream_creation/create_with_durations.rs
@@ -1,0 +1,33 @@
+use anchor_lang::{prelude::*, solana_program::sysvar::clock::Clock};
+
+use crate::instructions::create_with_timestamps;
+
+pub fn handler(
+    ctx: Context<create_with_timestamps::CreateWithTimestamps>,
+    cliff_duration: i64,
+    total_duration: i64,
+    deposited_amount: u64,
+    start_unlock: u64,
+    cliff_unlock: u64,
+    is_cancelable: bool,
+) -> Result<()> {
+    // Declare the start time as the current unix timestamp.
+    let start_time = Clock::get().unwrap().unix_timestamp;
+
+    // Calculate the cliff time by adding the cliff duration to the start time using checked math.
+    let cliff_time = start_time.checked_add(cliff_duration).unwrap();
+
+    // Calculate the end time by adding the total duration to the start time using checked math.
+    let end_time = start_time.checked_add(total_duration).unwrap();
+
+    create_with_timestamps::handler(
+        ctx,
+        start_time,
+        start_unlock,
+        cliff_time,
+        cliff_unlock,
+        end_time,
+        deposited_amount,
+        is_cancelable,
+    )
+}

--- a/programs/lockup/src/instructions/stream_creation/mod.rs
+++ b/programs/lockup/src/instructions/stream_creation/mod.rs
@@ -1,5 +1,7 @@
+pub mod create_with_durations;
 pub mod create_with_timestamps;
 pub mod prepare_for_stream_creation;
 
+pub use create_with_durations::*;
 pub use create_with_timestamps::*;
 pub use prepare_for_stream_creation::*;

--- a/programs/lockup/src/lib.rs
+++ b/programs/lockup/src/lib.rs
@@ -22,6 +22,26 @@ pub mod sablier_lockup {
         instructions::collect_fees::handler(ctx, lamports_amount)
     }
 
+    pub fn create_with_durations(
+        ctx: Context<CreateWithTimestamps>,
+        cliff_duration: i64,
+        total_duration: i64,
+        deposited_amount: u64,
+        start_unlock: u64,
+        cliff_unlock: u64,
+        is_cancelable: bool,
+    ) -> Result<()> {
+        instructions::create_with_durations::handler(
+            ctx,
+            cliff_duration,
+            total_duration,
+            deposited_amount,
+            start_unlock,
+            cliff_unlock,
+            is_cancelable,
+        )
+    }
+
     pub fn create_with_timestamps(
         ctx: Context<CreateWithTimestamps>,
         start_time: i64,


### PR DESCRIPTION
Closes #17 

Based on #35

The flow for using `create_with_duration` is like this: batch the `prepare_create_stream` instruction together with the `create_with_duration`. I didn't add a new context for this function, as I found it redundant to duplicate the same logic used in `create_with_timestamps`.