### PR TITLE
fix: cancel tests

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -9,6 +9,6 @@ sablier_lockup = "7KaQU8kYWDPcr9tbuMZWnWiVPUxQLjrjZ6jUU8rY1wqn"
 sablier_lockup = "7KaQU8kYWDPcr9tbuMZWnWiVPUxQLjrjZ6jUU8rY1wqn"
 
 [provider]
-cluster = "devnet"
-# cluster = "localnet"
+# cluster = "devnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"


### PR DESCRIPTION
chore: reset the default Anchor cluster to "localnet" (it makes more sense like this - otherwise, we'll be running our tests against Devnet, by default)

@andreivladbrg, to simplify the integration of these changes with the other big refactoring PR, we could, also, make them directly inside that PR (to have less conflicts to deal with).

The changes from this PR are insights I've got when preparing the next deployment for the @sablier-labs/frontend team.