### PR TITLE
chore: deployment

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,14 +1,18 @@
+[toolchain]
+
 [features]
 resolution = true
 skip-lint = false
 
 [programs.devnet]
-sablier_lockup = "7KaQU8kYWDPcr9tbuMZWnWiVPUxQLjrjZ6jUU8rY1wqn"
+sablier_lockup = "CCbf8DjzYCUgSTRGDiTiff6LkeMgt9q1XkbLMByMFtgc"
 
 [programs.localnet]
 sablier_lockup = "7KaQU8kYWDPcr9tbuMZWnWiVPUxQLjrjZ6jUU8rY1wqn"
 
+[registry]
+url = "https://api.apr.dev"
+
 [provider]
 cluster = "devnet"
-# cluster = "localnet"
 wallet = "~/.config/solana/id.json"

--- a/programs/lockup/src/lib.rs
+++ b/programs/lockup/src/lib.rs
@@ -6,7 +6,7 @@ pub mod utils;
 
 use crate::instructions::*;
 
-declare_id!("7KaQU8kYWDPcr9tbuMZWnWiVPUxQLjrjZ6jUU8rY1wqn"); // Localnet & Devnet Program ID
+declare_id!("CCbf8DjzYCUgSTRGDiTiff6LkeMgt9q1XkbLMByMFtgc"); // Localnet & Devnet Program ID
 
 #[program]
 pub mod sablier_lockup {


### PR DESCRIPTION
A couple of notes:

- The `[toolchain]` and `[registry]` sections inside `Anchor.toml` have re-appeared as a result of running `anchor keys sync` (this is one of the commands in the deployment script from #74). Being able to programmatically update the program id in `Anchor.toml` and `lib.rs` is more important, imo, than having a cleaner `Anchor.toml`, so, I suggest we accept this more verbose structure of `Anchor.toml`.

- Because the program id in `Anchor.toml` and `lib.rs` needs to be updated during each deployment (as we're now deploying each new version to a different address),
   - we need to commit these changes before building the artifacts we'll deploy &
   - the respective commit needs to remain accessible in the project history, so that the deployed program could be verified by @sablier-labs/frontend against the commit at a later time.
   - In light of this, I suggest going for a Merge Commit for the deployment PRs (the alternative is to update the "deployment commit id" once the respective PR has been integrated, but this isn't great, because it can't be automated: we will always have to remember to manually update the commit id upon PR integration).