### PR TITLE
chore: don't pin toolchain version in bun scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,5 +64,5 @@ jobs:
       - run: avm use latest
         shell: bash
 
-      - run: RUSTUP_TOOLCHAIN=nightly-2025-04-01 anchor build
+      - run: RUSTUP_TOOLCHAIN=nightly anchor build
         shell: bash

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "typescript": "^4.3.5"
   },
   "scripts": {
-    "build": "RUSTUP_TOOLCHAIN=nightly-2025-04-01 anchor build",
+    "build": "RUSTUP_TOOLCHAIN=nightly anchor build",
     "clean": "rm -rf .anchor target",
-    "fmt:rust": "RUSTUP_TOOLCHAIN=nightly-2025-04-01 cargo fmt",
-    "fmt:rust:check": "RUSTUP_TOOLCHAIN=nightly-2025-04-01 cargo fmt --check",
+    "fmt:rust": "RUSTUP_TOOLCHAIN=nightly cargo fmt",
+    "fmt:rust:check": "RUSTUP_TOOLCHAIN=nightly cargo fmt --check",
     "lint": "bun run fmt:rust:check && bun run lint:ts && bun run prettier:check",
     "lint:fix": "bun run fmt:rust && bun run lint:ts:fix && bun run prettier:write",
     "lint:ts": "eslint \"migrations/**/*.ts\" \"tests/**/*.ts\"",


### PR DESCRIPTION
We shouldn't reference a specific Rust toolchain version from the past, as it'll, normally, become incompatible with the rest of the dependencies quite soon - and require regular maintenance.

Referencing the generic toolchain kind (i.e. `nightly` or `stable`) is the way.