### PR TITLE
fix: add one to total supply in nft mint seed

### DIFF
--- a/programs/lockup/src/instructions/create_with_timestamps.rs
+++ b/programs/lockup/src/instructions/create_with_timestamps.rs
@@ -90,7 +90,7 @@ pub struct CreateWithTimestamps<'info> {
         init_if_needed,
         payer = sender,
         seeds = [STREAM_NFT_MINT_SEED,
-                 nft_collection_data.total_supply.to_le_bytes().as_ref()],
+                 (nft_collection_data.total_supply + 1).to_le_bytes().as_ref()],
         bump,
         mint::decimals = 0,
         mint::authority = nft_collection_mint, // TODO: make Treasury the authority, instead?


### PR DESCRIPTION
in the #99 PR, i missed a mistake that was made: the total supply is incremented before creating the stream data.  
so, to have the stream NFT mint "in sync" with the "stream data" account, we should add 1 in its seeds too.

**note:** the tests fail big time