### PR TITLE
chore: deployment for sablier_merkle_instant

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -6,7 +6,7 @@ skip-lint = false
 
 [programs.devnet]
 sablier_lockup = "DczGzCFQ5kHRBGVkH22HDdtduE4qaqopdc5HGLrAzfQD"
-sablier_merkle_instant = "9PgrjgDeajKz6268jbawtnXxfPrNHSoyAqtgQYW3Dp3h"
+sablier_merkle_instant = "G3R4BBqjo2hFdPh8EZSQfpj2u8hFL57cE9KUH57NZw28"
 
 [programs.localnet]
 sablier_lockup = "DczGzCFQ5kHRBGVkH22HDdtduE4qaqopdc5HGLrAzfQD"

--- a/programs/merkle_instant/src/lib.rs
+++ b/programs/merkle_instant/src/lib.rs
@@ -6,7 +6,7 @@ pub mod utils;
 
 use crate::instructions::*;
 
-declare_id!("9PgrjgDeajKz6268jbawtnXxfPrNHSoyAqtgQYW3Dp3h"); // Localnet & Devnet Program ID
+declare_id!("G3R4BBqjo2hFdPh8EZSQfpj2u8hFL57cE9KUH57NZw28"); // Localnet & Devnet Program ID
 
 #[program]
 pub mod sablier_merkle_instant {


### PR DESCRIPTION
Reminder: do **not** squash when merging ⚠️

Note: for some reason, the deployment script also changed the `sablier_lockup` address in `Anchor.toml`, as well 🤷
So, I had to manually update this PR, removing the `sablier_lockup` address change.