### PR TITLE
docs(lockup): add natspec like comments

### DIFF
--- a/programs/lockup/src/instructions/cancel.rs
+++ b/programs/lockup/src/instructions/cancel.rs
@@ -57,7 +57,7 @@ pub struct Cancel<'info> {
     pub associated_token_program: Program<'info, AssociatedToken>,
 }
 
-/// Refer to the {lib.rs#cancel} function explanatory comments.
+/// See the documentation of the {lib.rs#cancel} function.
 pub fn handler(ctx: Context<Cancel>) -> Result<()> {
     // Retrieve the stream amounts from storage.
     let stream_amounts = ctx.accounts.stream_data.amounts.clone();

--- a/programs/lockup/src/instructions/collect_fees.rs
+++ b/programs/lockup/src/instructions/collect_fees.rs
@@ -25,7 +25,7 @@ pub struct CollectFees<'info> {
     pub treasury: Box<Account<'info, Treasury>>,
 }
 
-/// Refer to the {lib.rs#collect_fees} function explanatory comments.
+/// See the documentation of the {lib.rs#collect_fees} function.
 pub fn handler(ctx: Context<CollectFees>) -> Result<()> {
     // Calculate the amount collectable from the treasury in lamport units.
     let collectable_amount = safe_collectable_amount(&ctx.accounts.treasury.to_account_info())?;

--- a/programs/lockup/src/instructions/create_with_durations.rs
+++ b/programs/lockup/src/instructions/create_with_durations.rs
@@ -2,7 +2,7 @@ use anchor_lang::{prelude::*, solana_program::sysvar::clock::Clock};
 
 use crate::instructions::create_with_timestamps;
 
-/// Refer to the {lib.rs#create_with_durations} function explanatory comments.
+/// See the documentation of the {lib.rs#create_with_durations} function.
 #[allow(clippy::too_many_arguments)]
 pub fn handler(
     ctx: Context<create_with_timestamps::CreateWithTimestamps>,

--- a/programs/lockup/src/instructions/create_with_timestamps.rs
+++ b/programs/lockup/src/instructions/create_with_timestamps.rs
@@ -155,7 +155,7 @@ pub struct CreateWithTimestamps<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-/// Refer to the {lib.rs#create_with_timestamps} function explanatory comments.
+/// See the documentation of the {lib.rs#create_with_timestamps} function.
 #[allow(clippy::too_many_arguments)]
 pub fn handler(
     ctx: Context<CreateWithTimestamps>,

--- a/programs/lockup/src/instructions/initialize.rs
+++ b/programs/lockup/src/instructions/initialize.rs
@@ -92,7 +92,7 @@ pub struct Initialize<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-/// Refer to the {lib.rs#initialize} function explanatory comments.
+/// See the documentation of the {lib.rs#initialize} function.
 pub fn handler(ctx: Context<Initialize>, fee_collector: Pubkey) -> Result<()> {
     ctx.accounts.treasury.initialize(ctx.bumps.treasury, fee_collector)?;
     ctx.accounts.nft_collection_data.initialize(ctx.bumps.nft_collection_data)?;

--- a/programs/lockup/src/instructions/renounce.rs
+++ b/programs/lockup/src/instructions/renounce.rs
@@ -30,7 +30,7 @@ pub struct Renounce<'info> {
     pub stream_data: Box<Account<'info, StreamData>>,
 }
 
-/// Refer to the {lib.rs#renounce} function explanatory comments.
+/// See the documentation of the {lib.rs#renounce} function.
 pub fn handler(ctx: Context<Renounce>) -> Result<()> {
     // Check: validate the renounce.
     check_renounce(

--- a/programs/lockup/src/instructions/view/refundable_amount_of.rs
+++ b/programs/lockup/src/instructions/view/refundable_amount_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_refundable_amount;
 
-/// Refer to the {lib.rs#refundable_amount_of} function explanatory comments.
+/// See the documentation of the {lib.rs#refundable_amount_of} function.
 pub fn handler(ctx: Context<StreamView>) -> Result<u64> {
     Ok(get_refundable_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts))
 }

--- a/programs/lockup/src/instructions/view/status_of.rs
+++ b/programs/lockup/src/instructions/view/status_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_streamed_amount;
 
-/// Refer to the {lib.rs#status_of} function explanatory comments.
+/// See the documentation of the {lib.rs#status_of} function.
 pub fn handler(ctx: Context<StreamView>) -> Result<StreamStatus> {
     let stream_data = &ctx.accounts.stream_data;
 

--- a/programs/lockup/src/instructions/view/streamed_amount_of.rs
+++ b/programs/lockup/src/instructions/view/streamed_amount_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_streamed_amount;
 
-/// Refer to the {lib.rs#streamed_amount_of} function explanatory comments.
+/// See the documentation of the {lib.rs#streamed_amount_of} function.
 pub fn handler(ctx: Context<StreamView>) -> Result<u64> {
     Ok(get_streamed_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts))
 }

--- a/programs/lockup/src/instructions/view/withdrawable_amount_of.rs
+++ b/programs/lockup/src/instructions/view/withdrawable_amount_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_withdrawable_amount;
 
-/// Refer to the {lib.rs#withdrawable_amount_of} function explanatory comments.
+/// See the documentation of the {lib.rs#withdrawable_amount_of} function.
 pub fn handler(ctx: Context<StreamView>) -> Result<u64> {
     Ok(get_withdrawable_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts))
 }

--- a/programs/lockup/src/instructions/withdraw.rs
+++ b/programs/lockup/src/instructions/withdraw.rs
@@ -88,7 +88,7 @@ pub struct Withdraw<'info> {
     pub associated_token_program: Program<'info, AssociatedToken>,
 }
 
-/// Refer to the {lib.rs#withdraw} function explanatory comments.
+/// See the documentation of the {lib.rs#withdraw} function.
 pub fn handler(ctx: Context<Withdraw>, amount: u64) -> Result<()> {
     // Check: validate the withdraw.
     check_withdraw(

--- a/programs/lockup/src/instructions/withdraw_max.rs
+++ b/programs/lockup/src/instructions/withdraw_max.rs
@@ -1,7 +1,7 @@
 use crate::{instructions::withdraw, utils::lockup_math::get_withdrawable_amount};
 use anchor_lang::prelude::*;
 
-/// Refer to the {lib.rs#withdraw_max} function explanatory comments.
+/// See the documentation of the {lib.rs#withdraw_max} function.
 pub fn handler(ctx: Context<withdraw::Withdraw>) -> Result<()> {
     let withdrawable_amount =
         get_withdrawable_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts);


### PR DESCRIPTION
Closes https://github.com/sablier-labs/solsab/issues/18 

**Notes:** 
-  the accounts listed in the "Accounts expected" are just the ones that are **needed** to be passed in `.account` (basically the ones from [base.ts](https://github.com/sablier-labs/solsab/blob/879eb7a114f4f853d0acc8e68442858e9b1b1839/tests/new/base.ts#L243))
- added the "STATE-CHANGING" and "READ-ONLY" headers
- i feel like we need to add more explanations about the NFT architecture (collection + nfts in create) wdyt?