### PR TITLE
refactor: add create fn in NftCollectionData

### DIFF
--- a/programs/lockup/src/instructions/create_with_timestamps.rs
+++ b/programs/lockup/src/instructions/create_with_timestamps.rs
@@ -208,9 +208,8 @@ pub fn handler(
         ctx.bumps.nft_collection_mint,
     )?;
 
-    // Effect: increment the total supply of the NFT collection. The increment is safe, as it would take many years to
-    // overflow 2^64.
-    ctx.accounts.nft_collection_data.total_supply += 1;
+    // Effect: increment the total supply of the NFT collection.
+    ctx.accounts.nft_collection_data.create()?;
 
     // Interaction: transfer tokens from the sender’s ATA to the StreamData ATA.
     transfer_tokens(

--- a/programs/lockup/src/state/nft_collection_data.rs
+++ b/programs/lockup/src/state/nft_collection_data.rs
@@ -8,6 +8,14 @@ pub struct NftCollectionData {
 }
 
 impl NftCollectionData {
+    // State update for the `create` instructions.
+    pub fn create(&mut self) -> Result<()> {
+        // The increment is safe, as it would take many years to overflow 2^64.
+        self.total_supply += 1;
+
+        Ok(())
+    }
+
     // State update for the `initialize` instruction.
     pub fn initialize(&mut self, bump: u8) -> Result<()> {
         self.bump = bump;


### PR DESCRIPTION
I know it's just one line, but I found it consistent here, in the `create` Ix, to have all state updates in separate functions rather than in the `handler` fn block itself.

No strong opinion, but I thought it was nice—lmk if you agree @IaroslavMazur.