### PR TITLE
test: declare ctx "globally" in tests

### DIFF
--- a/tests/lockup/unit/cancel.test.ts
+++ b/tests/lockup/unit/cancel.test.ts
@@ -13,9 +13,9 @@ import { assertEqStreamData, expectToThrow } from "../utils/assertions";
 import { Amount, Time } from "../utils/defaults";
 import { type Stream } from "../utils/types";
 
-describe("cancel", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("cancel", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new LockupTestContext();
@@ -134,7 +134,7 @@ describe("cancel", () => {
                   expectedStream.data.amounts.refunded = Amount.REFUND;
 
                   // Assert the cancelation
-                  await postCancelAssertions(ctx, salt, expectedStream, ZERO);
+                  await postCancelAssertions(salt, expectedStream, ZERO);
                 });
               });
 
@@ -157,7 +157,7 @@ describe("cancel", () => {
                   expectedStream.data.amounts.refunded = Amount.DEPOSIT;
 
                   // Assert the cancelation
-                  await postCancelAssertions(ctx, ctx.salts.default, expectedStream, beforeSenderBalance);
+                  await postCancelAssertions(ctx.salts.default, expectedStream, beforeSenderBalance);
                 });
               });
 
@@ -176,7 +176,7 @@ describe("cancel", () => {
                     expectedStream.data.amounts.refunded = Amount.REFUND;
 
                     // Assert the cancelation
-                    await postCancelAssertions(ctx, ctx.salts.default, expectedStream, beforeSenderBalance);
+                    await postCancelAssertions(ctx.salts.default, expectedStream, beforeSenderBalance);
                   });
                 });
 
@@ -198,7 +198,7 @@ describe("cancel", () => {
                     expectedStream.data.amounts.refunded = Amount.REFUND;
 
                     // Assert the cancelation
-                    await postCancelAssertions(ctx, salt, expectedStream, beforeSenderBalance);
+                    await postCancelAssertions(salt, expectedStream, beforeSenderBalance);
                   });
                 });
               });
@@ -210,7 +210,7 @@ describe("cancel", () => {
   });
 });
 
-async function postCancelAssertions(ctx: LockupTestContext, salt: BN, expectedStream: Stream, beforeSenderBalance: BN) {
+async function postCancelAssertions(salt: BN, expectedStream: Stream, beforeSenderBalance: BN) {
   // Assert that the Stream state has been updated correctly
   const actualStreamData = await ctx.fetchStreamData(salt);
   assertEqStreamData(actualStreamData, expectedStream.data);

--- a/tests/lockup/unit/collectFees.test.ts
+++ b/tests/lockup/unit/collectFees.test.ts
@@ -10,9 +10,9 @@ import { LockupTestContext } from "../context";
 import { expectToThrow } from "../utils/assertions";
 import { Amount, Time } from "../utils/defaults";
 
-describe("collectFees", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("collectFees", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new LockupTestContext();
@@ -32,7 +32,7 @@ describe("collectFees", () => {
 
     describe("when signer is not the authorized fee collector", () => {
       it("should revert", async () => {
-        await withdrawMultipleTimes(ctx);
+        await withdrawMultipleTimes();
         await expectToThrow(ctx.collectFees(ctx.eve.keys), CONSTRAINT_ADDRESS);
       });
     });
@@ -46,10 +46,10 @@ describe("collectFees", () => {
 
       describe("given accumulated fees", () => {
         it("should collect the fees", async () => {
-          await withdrawMultipleTimes(ctx);
+          await withdrawMultipleTimes();
 
           const beforeLamports = {
-            feeRecipient: await getFeeRecipientLamports(ctx),
+            feeRecipient: await getFeeRecipientLamports(),
             treasury: await ctx.getTreasuryLamports(),
           };
 
@@ -57,7 +57,7 @@ describe("collectFees", () => {
           await ctx.collectFees();
 
           const afterLamports = {
-            feeRecipient: await getFeeRecipientLamports(ctx),
+            feeRecipient: await getFeeRecipientLamports(),
             treasury: await ctx.getTreasuryLamports(),
           };
 
@@ -72,12 +72,12 @@ describe("collectFees", () => {
   });
 });
 
-async function getFeeRecipientLamports(ctx: LockupTestContext) {
+async function getFeeRecipientLamports() {
   return await ctx.getSenderLamports();
 }
 
 /// Helper function to withdraw multiple times so that there are fees collected
-async function withdrawMultipleTimes(ctx: LockupTestContext) {
+async function withdrawMultipleTimes() {
   await ctx.timeTravelTo(Time.MID_26_PERCENT);
   await ctx.withdrawMax();
   await ctx.timeTravelTo(Time.END);

--- a/tests/lockup/unit/createWithDurations.test.ts
+++ b/tests/lockup/unit/createWithDurations.test.ts
@@ -5,9 +5,9 @@ import { LockupTestContext } from "../context";
 import { assertEqStreamData, expectToThrow } from "../utils/assertions";
 import { Time } from "../utils/defaults";
 
-describe("createWithDurations", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("createWithDurations", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new LockupTestContext();

--- a/tests/lockup/unit/createWithTimestamps.test.ts
+++ b/tests/lockup/unit/createWithTimestamps.test.ts
@@ -9,9 +9,9 @@ import { LockupTestContext } from "../context";
 import { assertEqStreamData, expectToThrow } from "../utils/assertions";
 import { AMOUNTS, Amount, TIMESTAMPS, Time, UNLOCK_AMOUNTS } from "../utils/defaults";
 
-describe("createWithTimestamps", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("createWithTimestamps", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new LockupTestContext();
@@ -122,7 +122,7 @@ describe("createWithTimestamps", () => {
                     expectedStream.data.timestamps.cliff = ZERO;
                     expectedStream.data.amounts = AMOUNTS({ cliffUnlock: ZERO, startUnlock: ZERO });
 
-                    await assertStreamCreation(ctx, salt, beforeSenderTokenBalance, expectedStream);
+                    await assertStreamCreation(salt, beforeSenderTokenBalance, expectedStream);
                   });
                 });
               });
@@ -174,7 +174,7 @@ describe("createWithTimestamps", () => {
                           const beforeSenderTokenBalance = await getATABalance(ctx.banksClient, ctx.sender.usdcATA);
                           const salt = await ctx.createWithTimestamps();
 
-                          await assertStreamCreation(ctx, salt, beforeSenderTokenBalance);
+                          await assertStreamCreation(salt, beforeSenderTokenBalance);
                         });
                       });
 
@@ -184,7 +184,6 @@ describe("createWithTimestamps", () => {
                           const salt = await ctx.createWithTimestampsToken2022();
 
                           await assertStreamCreation(
-                            ctx,
                             salt,
                             beforeSenderTokenBalance,
                             ctx.defaultStreamToken2022({ salt: salt }),
@@ -204,10 +203,9 @@ describe("createWithTimestamps", () => {
 });
 
 async function assertStreamCreation(
-  ctx: LockupTestContext,
   salt: BN,
   beforeSenderTokenBalance: BN,
-  expectedStream = ctx.defaultStream({ salt: salt }),
+  expectedStream = ctx.defaultStream({ salt }),
 ) {
   await assertAccountExists(ctx, expectedStream.nftMintAddress, "Stream NFT Mint");
   await assertAccountExists(ctx, expectedStream.dataAddress, "Stream Data");

--- a/tests/lockup/unit/initialize.test.ts
+++ b/tests/lockup/unit/initialize.test.ts
@@ -6,9 +6,9 @@ import { assertAccountExists, assertEqualBn } from "../../common/assertions";
 import { LockupTestContext } from "../context";
 import { Seed } from "../utils/defaults";
 
-describe("initialize", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("initialize", () => {
   beforeEach(async () => {
     ctx = new LockupTestContext();
     await ctx.setUpLockup({ initProgram: false });

--- a/tests/lockup/unit/renounce.test.ts
+++ b/tests/lockup/unit/renounce.test.ts
@@ -8,9 +8,9 @@ import { LockupTestContext } from "../context";
 import { assertEqStreamData, expectToThrow } from "../utils/assertions";
 import { Time } from "../utils/defaults";
 
-describe("renounce", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("renounce", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new LockupTestContext();

--- a/tests/lockup/unit/withdraw.test.ts
+++ b/tests/lockup/unit/withdraw.test.ts
@@ -18,9 +18,9 @@ import { LockupTestContext } from "../context";
 import { assertEqStreamData, expectToThrow } from "../utils/assertions";
 import { Amount, Time } from "../utils/defaults";
 
-describe("withdraw", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("withdraw", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new LockupTestContext();
@@ -161,7 +161,6 @@ describe("withdraw", () => {
                       expectedStreamData.amounts.withdrawn = Amount.WITHDRAW;
 
                       await postWithdrawAssertions(
-                        ctx,
                         ctx.salts.default,
                         treasuryLamportsBefore,
                         ctx.sender.usdcATA,
@@ -191,7 +190,6 @@ describe("withdraw", () => {
                     expectedStreamData.amounts.withdrawn = Amount.WITHDRAW;
 
                     await postWithdrawAssertions(
-                      ctx,
                       ctx.salts.default,
                       treasuryLamportsBefore,
                       ctx.recipient.usdcATA,
@@ -226,7 +224,6 @@ describe("withdraw", () => {
                       expectedStreamData.isDepleted = true;
 
                       await postWithdrawAssertions(
-                        ctx,
                         ctx.salts.default,
                         treasuryLamportsBefore,
                         ctx.recipient.usdcATA,
@@ -260,7 +257,6 @@ describe("withdraw", () => {
                         expectedStreamData.amounts.withdrawn = Amount.WITHDRAW;
 
                         await postWithdrawAssertions(
-                          ctx,
                           ctx.salts.default,
                           treasuryLamportsBefore,
                           ctx.recipient.usdcATA,
@@ -286,7 +282,6 @@ describe("withdraw", () => {
                           const expectedStreamData = ctx.defaultStream().data;
                           expectedStreamData.amounts.withdrawn = Amount.WITHDRAW;
                           await postWithdrawAssertions(
-                            ctx,
                             ctx.salts.default,
                             treasuryLamportsBefore,
                             ctx.recipient.usdcATA,
@@ -316,7 +311,6 @@ describe("withdraw", () => {
                           }).data;
                           expectedStreamData.amounts.withdrawn = Amount.WITHDRAW;
                           await postWithdrawAssertions(
-                            ctx,
                             salt,
                             treasuryLamportsBefore,
                             ctx.recipient.daiATA,
@@ -338,7 +332,6 @@ describe("withdraw", () => {
 });
 
 async function postWithdrawAssertions(
-  ctx: LockupTestContext,
   salt: BN,
   treasuryLamportsBefore: BN,
   withdrawalRecipientATA: PublicKey,

--- a/tests/lockup/unit/withdrawMax.test.ts
+++ b/tests/lockup/unit/withdrawMax.test.ts
@@ -5,9 +5,9 @@ import { LockupTestContext } from "../context";
 import { assertEqStreamData, expectToThrow } from "../utils/assertions";
 import { Amount, Time } from "../utils/defaults";
 
-describe("withdrawMax", () => {
-  let ctx: LockupTestContext;
+let ctx: LockupTestContext;
 
+describe("withdrawMax", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new LockupTestContext();

--- a/tests/merkle-instant/unit/claim.test.ts
+++ b/tests/merkle-instant/unit/claim.test.ts
@@ -9,9 +9,9 @@ import { MerkleInstantTestContext } from "../context";
 import { expectToThrow } from "../utils/assertions";
 import { Amount, Campaign, Time } from "../utils/defaults";
 
-describe("claim", () => {
-  let ctx: MerkleInstantTestContext;
+let ctx: MerkleInstantTestContext;
 
+describe("claim", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new MerkleInstantTestContext();
@@ -107,7 +107,7 @@ describe("claim", () => {
                   });
 
                   // Test the campaign
-                  await testClaim(ctx, campaign, ctx.recipient.keys, ctx.randomToken, ProgramId.TOKEN, false);
+                  await testClaim(campaign, ctx.recipient.keys, ctx.randomToken, ProgramId.TOKEN, false);
                 });
               });
 
@@ -115,7 +115,7 @@ describe("claim", () => {
                 describe("when the claimer is not the recipient", () => {
                   it("should claim the airdrop", async () => {
                     // Test the claim.
-                    await testClaim(ctx, ctx.defaultCampaign, ctx.campaignCreator.keys);
+                    await testClaim(ctx.defaultCampaign, ctx.campaignCreator.keys);
                   });
                 });
 
@@ -123,20 +123,14 @@ describe("claim", () => {
                   describe("given token SPL standard", () => {
                     it("should claim the airdrop", async () => {
                       // Claim from the Campaign
-                      await testClaim(ctx);
+                      await testClaim();
                     });
                   });
 
                   describe("given token 2022 standard", () => {
                     it("should claim the airdrop", async () => {
                       // Test the claim.
-                      await testClaim(
-                        ctx,
-                        ctx.defaultCampaignToken2022,
-                        ctx.recipient.keys,
-                        ctx.dai,
-                        ProgramId.TOKEN_2022,
-                      );
+                      await testClaim(ctx.defaultCampaignToken2022, ctx.recipient.keys, ctx.dai, ProgramId.TOKEN_2022);
                     });
                   });
                 });
@@ -151,7 +145,6 @@ describe("claim", () => {
 
 /// Common test function to test the claim functionality
 async function testClaim(
-  ctx: MerkleInstantTestContext,
   campaign = ctx.defaultCampaign,
   claimer = ctx.recipient.keys,
   tokenMint = ctx.usdc,
@@ -159,7 +152,7 @@ async function testClaim(
   recipientAtaExists = true,
 ): Promise<void> {
   // Assert that the claim was not made yet.
-  assert.isFalse(await hasClaimed(ctx));
+  assert.isFalse(await hasClaimed());
 
   // Get the Campaign's data before claiming
   const campaignDataBefore = await ctx.fetchCampaignData(campaign);
@@ -189,7 +182,7 @@ async function testClaim(
   assertEqualBn(campaignDataAfter.firstClaimTime, Time.GENESIS);
 
   // Assert that the claim has been made
-  assert.isTrue(await hasClaimed(ctx, campaign));
+  assert.isTrue(await hasClaimed(campaign));
 
   const campaignAtaBalanceAfter = await getATABalanceMint(ctx.banksClient, campaign, tokenMint);
 
@@ -214,7 +207,7 @@ async function testClaim(
 }
 
 // Implicitly tests the `has_claimed` Ix works.
-async function hasClaimed(ctx: MerkleInstantTestContext, campaign = ctx.defaultCampaign): Promise<boolean> {
+async function hasClaimed(campaign = ctx.defaultCampaign): Promise<boolean> {
   return await ctx.merkleInstant.methods
     .hasClaimed(ctx.defaultIndex)
     .accounts({

--- a/tests/merkle-instant/unit/collectFees.test.ts
+++ b/tests/merkle-instant/unit/collectFees.test.ts
@@ -9,9 +9,9 @@ import { MerkleInstantTestContext } from "../context";
 import { expectToThrow } from "../utils/assertions";
 import { Amount } from "../utils/defaults";
 
-describe("collectFees", () => {
-  let ctx: MerkleInstantTestContext;
+let ctx: MerkleInstantTestContext;
 
+describe("collectFees", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new MerkleInstantTestContext();
@@ -53,7 +53,7 @@ describe("collectFees", () => {
           await ctx.claim({ claimerKeys: ctx.recipient.keys });
 
           const beforeLamports = {
-            feeRecipient: await getFeeRecipientLamports(ctx),
+            feeRecipient: await getFeeRecipientLamports(),
             treasury: await ctx.getTreasuryLamports(),
           };
 
@@ -61,7 +61,7 @@ describe("collectFees", () => {
           await ctx.collectFees();
 
           const afterLamports = {
-            feeRecipient: await getFeeRecipientLamports(ctx),
+            feeRecipient: await getFeeRecipientLamports(),
             treasury: await ctx.getTreasuryLamports(),
           };
 
@@ -76,6 +76,6 @@ describe("collectFees", () => {
   });
 });
 
-async function getFeeRecipientLamports(ctx: MerkleInstantTestContext) {
+async function getFeeRecipientLamports() {
   return await ctx.getLamportsOf(ctx.recipient.keys.publicKey);
 }

--- a/tests/merkle-instant/unit/createCampaign.test.ts
+++ b/tests/merkle-instant/unit/createCampaign.test.ts
@@ -2,9 +2,9 @@ import { beforeAll, beforeEach, describe, it } from "vitest";
 import { MerkleInstantTestContext } from "../context";
 import { assertEqCampaignData, expectToThrow } from "../utils/assertions";
 
-describe("createCampaign", () => {
-  let ctx: MerkleInstantTestContext;
+let ctx: MerkleInstantTestContext;
 
+describe("createCampaign", () => {
   describe("when the program is not initialized", () => {
     beforeAll(async () => {
       ctx = new MerkleInstantTestContext();

--- a/tests/merkle-instant/unit/initialize.test.ts
+++ b/tests/merkle-instant/unit/initialize.test.ts
@@ -3,9 +3,9 @@ import { sleepFor } from "../../../lib/helpers";
 import { assertAccountExists } from "../../common/assertions";
 import { MerkleInstantTestContext } from "../context";
 
-describe("initialize", () => {
-  let ctx: MerkleInstantTestContext;
+let ctx: MerkleInstantTestContext;
 
+describe("initialize", () => {
   beforeEach(async () => {
     ctx = new MerkleInstantTestContext();
     await ctx.setUpMerkleInstant({


### PR DESCRIPTION
Depends on https://github.com/sablier-labs/solsab/pull/172

I noticed that we can declare `ctx` in the test files globally instead of doing it in the describe block and then pass it to other functions