### PR TITLE
docs: add "fn" in the crate comments

### DIFF
--- a/programs/lockup/src/instructions/cancel.rs
+++ b/programs/lockup/src/instructions/cancel.rs
@@ -80,7 +80,7 @@ pub struct Cancel<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// See the documentation for [`crate::sablier_lockup::cancel`].
+/// See the documentation for [`fn@crate::sablier_lockup::cancel`].
 pub fn handler(ctx: Context<Cancel>) -> Result<()> {
     // Retrieve the stream amounts from storage.
     let stream_amounts = ctx.accounts.stream_data.amounts.clone();

--- a/programs/lockup/src/instructions/collect_fees.rs
+++ b/programs/lockup/src/instructions/collect_fees.rs
@@ -31,7 +31,7 @@ pub struct CollectFees<'info> {
     pub treasury: Box<Account<'info, Treasury>>,
 }
 
-/// See the documentation for [`crate::sablier_lockup::collect_fees`].
+/// See the documentation for [`fn@crate::sablier_lockup::collect_fees`].
 pub fn handler(ctx: Context<CollectFees>) -> Result<()> {
     // Calculate the amount collectable from the treasury in lamport units.
     let collectible_amount = safe_collectible_amount(&ctx.accounts.treasury.to_account_info())?;

--- a/programs/lockup/src/instructions/create_with_durations.rs
+++ b/programs/lockup/src/instructions/create_with_durations.rs
@@ -2,7 +2,7 @@ use anchor_lang::{prelude::*, solana_program::sysvar::clock::Clock};
 
 use crate::instructions::create_with_timestamps;
 
-/// See the documentation for [`crate::sablier_lockup::create_with_durations`].
+/// See the documentation for [`fn@crate::sablier_lockup::create_with_durations_ll`].
 #[allow(clippy::too_many_arguments)]
 pub fn handler(
     ctx: Context<create_with_timestamps::CreateWithTimestamps>,

--- a/programs/lockup/src/instructions/create_with_timestamps.rs
+++ b/programs/lockup/src/instructions/create_with_timestamps.rs
@@ -196,7 +196,7 @@ pub struct CreateWithTimestamps<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-/// See the documentation for [`crate::sablier_lockup::create_with_timestamps`].
+/// See the documentation for [`fn@crate::sablier_lockup::create_with_timestamps_ll`].
 #[allow(clippy::too_many_arguments)]
 pub fn handler(
     ctx: Context<CreateWithTimestamps>,

--- a/programs/lockup/src/instructions/initialize.rs
+++ b/programs/lockup/src/instructions/initialize.rs
@@ -123,7 +123,7 @@ pub struct Initialize<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// See the documentation for [`crate::sablier_lockup::initialize`].
+/// See the documentation for [`fn@crate::sablier_lockup::initialize`].
 pub fn handler(
     ctx: Context<Initialize>,
     fee_collector: Pubkey,

--- a/programs/lockup/src/instructions/renounce.rs
+++ b/programs/lockup/src/instructions/renounce.rs
@@ -36,7 +36,7 @@ pub struct Renounce<'info> {
     pub stream_nft_mint: Box<InterfaceAccount<'info, Mint>>,
 }
 
-/// See the documentation for [`crate::sablier_lockup::renounce`].
+/// See the documentation for [`fn@crate::sablier_lockup::renounce`].
 pub fn handler(ctx: Context<Renounce>) -> Result<()> {
     // Check: validate the renounce.
     check_renounce(

--- a/programs/lockup/src/instructions/view/refundable_amount_of.rs
+++ b/programs/lockup/src/instructions/view/refundable_amount_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_refundable_amount;
 
-/// See the documentation for [`crate::sablier_lockup::refundable_amount_of`].
+/// See the documentation for [`fn@crate::sablier_lockup::refundable_amount_of`].
 pub fn handler(ctx: Context<StreamView>) -> Result<u64> {
     Ok(get_refundable_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts))
 }

--- a/programs/lockup/src/instructions/view/status_of.rs
+++ b/programs/lockup/src/instructions/view/status_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_streamed_amount;
 
-/// See the documentation for [`crate::sablier_lockup::status_of`].
+/// See the documentation for [`fn@crate::sablier_lockup::status_of`].
 pub fn handler(ctx: Context<StreamView>) -> Result<StreamStatus> {
     let stream_data = &ctx.accounts.stream_data;
 

--- a/programs/lockup/src/instructions/view/streamed_amount_of.rs
+++ b/programs/lockup/src/instructions/view/streamed_amount_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_streamed_amount;
 
-/// See the documentation for [`crate::sablier_lockup::streamed_amount_of`].
+/// See the documentation for [`fn@crate::sablier_lockup::streamed_amount_of`].
 pub fn handler(ctx: Context<StreamView>) -> Result<u64> {
     Ok(get_streamed_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts))
 }

--- a/programs/lockup/src/instructions/view/withdrawable_amount_of.rs
+++ b/programs/lockup/src/instructions/view/withdrawable_amount_of.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::StreamView;
 use crate::utils::lockup_math::get_withdrawable_amount;
 
-/// See the documentation for [`crate::sablier_lockup::withdrawable_amount_of`].
+/// See the documentation for [`fn@crate::sablier_lockup::withdrawable_amount_of`].
 pub fn handler(ctx: Context<StreamView>) -> Result<u64> {
     Ok(get_withdrawable_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts))
 }

--- a/programs/lockup/src/instructions/withdraw.rs
+++ b/programs/lockup/src/instructions/withdraw.rs
@@ -133,7 +133,7 @@ pub struct Withdraw<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// See the documentation for [`crate::sablier_lockup::withdraw`].
+/// See the documentation for [`fn@crate::sablier_lockup::withdraw`].
 pub fn handler(ctx: Context<Withdraw>, amount: u64) -> Result<()> {
     // Check: validate the withdraw.
     check_withdraw(

--- a/programs/lockup/src/instructions/withdraw_max.rs
+++ b/programs/lockup/src/instructions/withdraw_max.rs
@@ -1,7 +1,7 @@
 use crate::{instructions::withdraw, utils::lockup_math::get_withdrawable_amount};
 use anchor_lang::prelude::*;
 
-/// See the documentation for [`crate::sablier_lockup::withdraw_max`].
+/// See the documentation for [`fn@crate::sablier_lockup::withdraw_max`].
 pub fn handler(ctx: Context<withdraw::Withdraw>) -> Result<()> {
     let withdrawable_amount =
         get_withdrawable_amount(&ctx.accounts.stream_data.timestamps, &ctx.accounts.stream_data.amounts);

--- a/programs/lockup/src/lib.rs
+++ b/programs/lockup/src/lib.rs
@@ -69,19 +69,19 @@ pub mod sablier_lockup {
     ///
     /// # Accounts Expected
     ///
-    /// Refer to the accounts in [`create_with_timestamps`].
+    /// Refer to the accounts in [`fn@crate::sablier_lockup::create_with_timestamps_ll`].
     ///
     /// # Parameters
     ///
-    /// Refer to the parameters in [`create_with_timestamps`].
+    /// Refer to the parameters in [`fn@crate::sablier_lockup::create_with_timestamps_ll`].
     ///
     /// # Notes
     ///
-    /// Refer to the notes in [`create_with_timestamps`].
+    /// Refer to the notes in [`fn@crate::sablier_lockup::create_with_timestamps_ll`].
     ///
     /// # Requirements
     ///
-    /// Refer to the requirements in [`create_with_timestamps`].
+    /// Refer to the requirements in [`fn@crate::sablier_lockup::create_with_timestamps_ll`].
     #[allow(clippy::too_many_arguments)]
     pub fn create_with_durations_ll(
         ctx: Context<CreateWithTimestamps>,
@@ -242,15 +242,15 @@ pub mod sablier_lockup {
     ///
     /// # Accounts Expected
     ///
-    /// Refer to the accounts in [`withdraw`].
+    /// Refer to the accounts in [`fn@crate::sablier_lockup::withdraw`].
     ///
     /// # Notes
     ///
-    /// Refer to the notes in [`withdraw`].
+    /// Refer to the notes in [`fn@crate::sablier_lockup::withdraw`].
     ///
     /// # Requirements
     ///
-    /// Refer to the requirements in [`withdraw`].
+    /// Refer to the requirements in [`fn@crate::sablier_lockup::withdraw`].
     pub fn withdraw_max(ctx: Context<Withdraw>) -> Result<()> {
         instructions::withdraw_max::handler(ctx)
     }

--- a/programs/lockup/src/state/lockup.rs
+++ b/programs/lockup/src/state/lockup.rs
@@ -37,7 +37,7 @@ pub struct Timestamps {
 }
 
 impl StreamData {
-    /// State update for the [`crate::sablier_lockup::cancel`] instruction.
+    /// State update for the [`fn@crate::sablier_lockup::cancel`] instruction.
     pub fn cancel(&mut self, sender_amount: u64, recipient_amount: u64) -> Result<()> {
         self.amounts.refunded = sender_amount;
         self.is_cancelable = false;
@@ -49,7 +49,7 @@ impl StreamData {
         Ok(())
     }
 
-    /// State update for the [`crate::sablier_lockup::create_with_timestamps`] instruction.
+    /// State update for the [`fn@crate::sablier_lockup::create_with_timestamps_ll`] instruction.
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         &mut self,
@@ -88,14 +88,14 @@ impl StreamData {
         Ok(())
     }
 
-    /// State update for the [`crate::sablier_lockup::renounce`] instruction.
+    /// State update for the [`fn@crate::sablier_lockup::renounce`] instruction.
     pub fn renounce(&mut self) -> Result<()> {
         self.is_cancelable = false;
 
         Ok(())
     }
 
-    /// State update for the [`crate::sablier_lockup::withdraw`] instruction.
+    /// State update for the [`fn@crate::sablier_lockup::withdraw`] instruction.
     pub fn withdraw(&mut self, amount: u64) -> Result<()> {
         self.amounts.withdrawn = self.amounts.withdrawn.checked_add(amount).expect("Withdrawn amount overflow");
 

--- a/programs/lockup/src/state/nft_collection_data.rs
+++ b/programs/lockup/src/state/nft_collection_data.rs
@@ -8,7 +8,7 @@ pub struct NftCollectionData {
 }
 
 impl NftCollectionData {
-    /// State update for the [`crate::sablier_lockup::create_with_timestamps`] instruction.
+    /// State update for the [`fn@crate::sablier_lockup::create_with_timestamps_ll`] instruction.
     pub fn create(&mut self) -> Result<()> {
         // The increment is safe, as it would take many years to overflow 2^64.
         self.total_supply += 1;
@@ -16,7 +16,7 @@ impl NftCollectionData {
         Ok(())
     }
 
-    /// State update for the [`crate::sablier_lockup::initialize`] instruction.
+    /// State update for the [`fn@crate::sablier_lockup::initialize`] instruction.
     pub fn initialize(&mut self, bump: u8) -> Result<()> {
         self.bump = bump;
         self.total_supply = 0;

--- a/programs/lockup/src/state/treasury.rs
+++ b/programs/lockup/src/state/treasury.rs
@@ -10,7 +10,7 @@ pub struct Treasury {
 }
 
 impl Treasury {
-    /// State update for the [`crate::sablier_lockup::initialize`] instruction.
+    /// State update for the [`fn@crate::sablier_lockup::initialize`] instruction.
     pub fn initialize(
         &mut self,
         bump: u8,

--- a/programs/merkle_instant/src/instructions/claim.rs
+++ b/programs/merkle_instant/src/instructions/claim.rs
@@ -113,7 +113,7 @@ pub struct Claim<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// See the documentation for [`crate::sablier_merkle_instant::claim`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::claim`].
 pub fn handler(ctx: Context<Claim>, index: u32, amount: u64, merkle_proof: Vec<[u8; 32]>) -> Result<()> {
     let campaign = ctx.accounts.campaign.clone();
     let airdrop_token_mint = ctx.accounts.airdrop_token_mint.clone();

--- a/programs/merkle_instant/src/instructions/clawback.rs
+++ b/programs/merkle_instant/src/instructions/clawback.rs
@@ -70,7 +70,7 @@ pub struct Clawback<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// See the documentation for [`crate::sablier_merkle_instant::clawback`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::clawback`].
 pub fn handler(ctx: Context<Clawback>, amount: u64) -> Result<()> {
     let campaign = ctx.accounts.campaign.clone();
     let airdrop_token_mint = ctx.accounts.airdrop_token_mint.clone();

--- a/programs/merkle_instant/src/instructions/collect_fees.rs
+++ b/programs/merkle_instant/src/instructions/collect_fees.rs
@@ -31,7 +31,7 @@ pub struct CollectFees<'info> {
     pub treasury: Box<Account<'info, Treasury>>,
 }
 
-/// See the documentation for [`crate::sablier_merkle_instant::collect_fees`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::collect_fees`].
 pub fn handler(ctx: Context<CollectFees>) -> Result<()> {
     // Calculate the amount collectable from the treasury in lamport units.
     let collectible_amount = safe_collectible_amount(&ctx.accounts.treasury.to_account_info())?;

--- a/programs/merkle_instant/src/instructions/create_campaign.rs
+++ b/programs/merkle_instant/src/instructions/create_campaign.rs
@@ -78,7 +78,7 @@ pub struct CreateCampaign<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// See the documentation for [`crate::sablier_merkle_instant::create_campaign`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::create_campaign`].
 #[allow(clippy::too_many_arguments)]
 pub fn handler(
     ctx: Context<CreateCampaign>,

--- a/programs/merkle_instant/src/instructions/initialize.rs
+++ b/programs/merkle_instant/src/instructions/initialize.rs
@@ -34,7 +34,7 @@ pub struct Initialize<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// See the documentation for [`crate::sablier_merkle_instant::initialize`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::initialize`].
 pub fn handler(
     ctx: Context<Initialize>,
     fee_collector: Pubkey,

--- a/programs/merkle_instant/src/instructions/view/campaign_view.rs
+++ b/programs/merkle_instant/src/instructions/view/campaign_view.rs
@@ -12,7 +12,7 @@ pub struct CampaignView<'info> {
     pub campaign: Box<Account<'info, Campaign>>,
 }
 
-/// See the documentation for [`crate::sablier_merkle_instant::campaign_view`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::campaign_view`].
 pub fn handler(ctx: Context<CampaignView>) -> Result<Campaign> {
     Ok(ctx.accounts.campaign.clone().into_inner())
 }

--- a/programs/merkle_instant/src/instructions/view/has_campaign_started.rs
+++ b/programs/merkle_instant/src/instructions/view/has_campaign_started.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::CampaignView;
 use crate::utils::validations::has_campaign_started;
 
-/// See the documentation for [`crate::sablier_merkle_instant::has_campaign_started`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::has_campaign_started`].
 pub fn handler(ctx: Context<CampaignView>) -> Result<bool> {
     has_campaign_started(ctx.accounts.campaign.campaign_start_time)
 }

--- a/programs/merkle_instant/src/instructions/view/has_expired.rs
+++ b/programs/merkle_instant/src/instructions/view/has_expired.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::CampaignView;
 use crate::utils::validations::has_expired;
 
-/// See the documentation for [`crate::sablier_merkle_instant::has_expired`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::has_expired`].
 pub fn handler(ctx: Context<CampaignView>) -> Result<bool> {
     has_expired(ctx.accounts.campaign.expiration_time)
 }

--- a/programs/merkle_instant/src/instructions/view/has_grace_period_passed.rs
+++ b/programs/merkle_instant/src/instructions/view/has_grace_period_passed.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use super::CampaignView;
 use crate::utils::validations::has_grace_period_passed;
 
-/// See the documentation for [`crate::sablier_merkle_instant::has_grace_period_passed`].
+/// See the documentation for [`fn@crate::sablier_merkle_instant::has_grace_period_passed`].
 pub fn handler(ctx: Context<CampaignView>) -> Result<bool> {
     has_grace_period_passed(ctx.accounts.campaign.expiration_time)
 }

--- a/programs/merkle_instant/src/state/campaign.rs
+++ b/programs/merkle_instant/src/state/campaign.rs
@@ -24,7 +24,7 @@ pub struct Campaign {
 }
 
 impl Campaign {
-    /// State update for the [`crate::sablier_merkle_instant::claim`] instruction.
+    /// State update for the [`fn@crate::sablier_merkle_instant::claim`] instruction.
     pub fn claim(&mut self) -> Result<()> {
         // Update the first claim time to the current time.
         if self.first_claim_time == 0 {
@@ -34,7 +34,7 @@ impl Campaign {
         Ok(())
     }
 
-    /// State update for the [`crate::sablier_merkle_instant::create_campaign`] instruction.
+    /// State update for the [`fn@crate::sablier_merkle_instant::create_campaign`] instruction.
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         &mut self,

--- a/programs/merkle_instant/src/state/treasury.rs
+++ b/programs/merkle_instant/src/state/treasury.rs
@@ -10,7 +10,7 @@ pub struct Treasury {
 }
 
 impl Treasury {
-    /// State update for the [`crate::sablier_merkle_instant::initialize`] instruction.
+    /// State update for the [`fn@crate::sablier_merkle_instant::initialize`] instruction.
     pub fn initialize(
         &mut self,
         bump: u8,


### PR DESCRIPTION
the motivation for this is that if you click on this, for example:  
https://github.com/sablier-labs/solsab/blob/0ceed58137824b9b80621b311ece961e0ebc6582/programs/lockup/src/lib.rs#L245

instead of directing you to the above function, it will take you to `instructions/withdraw.rs`  

### Before

https://github.com/user-attachments/assets/ff8f936f-f7f2-4b76-8326-068cedabd6c3

### Now

https://github.com/user-attachments/assets/612bf46c-414b-4fca-a875-c7b852245f73



