### PR TITLE
scripts: set solana config automatically

### DIFF
--- a/scripts/bash/deploy-programs.sh
+++ b/scripts/bash/deploy-programs.sh
@@ -82,11 +82,13 @@ MAINNET_FLAG=false
 PROGRAMS=()
 VALID_PROGRAMS=("sablier_lockup" "sablier_merkle_instant")
 
-CLUSTER=""
-export ANCHOR_PROVIDER_URL=""
+CLUSTER="devnet"
+export ANCHOR_PROVIDER_URL="https://api.devnet.solana.com"
 
-# Declare the init scripts mapping
+# Define the init scripts mapping
 declare -A INIT_SCRIPTS
+INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup-and-create-streams.ts"
+INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant-and-create-campaign.ts"
 
 # Define the program configuration mapping
 declare -A PROGRAM_CONFIG
@@ -137,12 +139,6 @@ if [[ "$MAINNET_FLAG" == true ]]; then
     # Note: we don't want to create demo streams/campaigns on mainnet
     INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup.ts"
     INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant.ts"
-else
-    CLUSTER="devnet"
-    ANCHOR_PROVIDER_URL="https://api.devnet.solana.com"
-
-    INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup-and-create-streams.ts"
-    INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant-and-create-campaign.ts"
 fi
 
 # Configure Solana CLI to use the correct provider

--- a/scripts/bash/deploy-programs.sh
+++ b/scripts/bash/deploy-programs.sh
@@ -82,16 +82,15 @@ MAINNET_FLAG=false
 PROGRAMS=()
 VALID_PROGRAMS=("sablier_lockup" "sablier_merkle_instant")
 
-# Configuration
-CLUSTER="devnet"
-PROVIDER_URL="https://api.devnet.solana.com"
+CLUSTER=""
+export ANCHOR_PROVIDER_URL=""
 
-# The init scripts mapping
+# The init scripts mappings
 declare -A INIT_SCRIPTS
 INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup-and-create-streams.ts"
 INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant-and-create-campaign.ts"
 
-# Program configuration mapping
+# Program configuration mappings
 declare -A PROGRAM_CONFIG
 PROGRAM_CONFIG["sablier_lockup"]="programs/lockup/src/lib.rs"
 PROGRAM_CONFIG["sablier_merkle_instant"]="programs/merkle_instant/src/lib.rs"
@@ -132,46 +131,44 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# If mainnet flag is passed, set the variables accordingly
+# Set the variables depending on whether the mainnet flag has been passed
 if [[ "$MAINNET_FLAG" == true ]]; then
     CLUSTER="mainnet"
-    PROVIDER_URL="https://api.mainnet-beta.solana.com"
+    ANCHOR_PROVIDER_URL="https://api.mainnet-beta.solana.com"
+
     # We don't want to create demo streams/campaigns on mainnet
     INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup.ts"
     INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant.ts"
-fi
-
-CONFIG_PATH="$HOME/.config/solana/cli/config.yml"
-
-# Check if the config file exists before editing
-if [[ -f "$CONFIG_PATH" ]]; then
-    # Change the config file with the correct provider
-    sed -i "" "s|^json_rpc_url:.*|json_rpc_url: $PROVIDER_URL|" "$CONFIG_PATH"
-    log_info "Updated json_rpc_url in $CONFIG_PATH"
 else
-    log_warning "Config file $CONFIG_PATH not found, skipping json_rpc_url update."
+    CLUSTER="devnet"
+    ANCHOR_PROVIDER_URL="https://api.devnet.solana.com"
 fi
 
-# Validate input
+# Configure Solana CLI to use the correct provider
+solana config set --url $ANCHOR_PROVIDER_URL
+
+# ---------------------------------------------------------------------------- #
+#                               INPUT VALIDATION                               #
+# ---------------------------------------------------------------------------- #
+
+# Assert that at least one program has been specified
 if [[ ${#PROGRAMS[@]} -eq 0 ]]; then
     show_usage_and_exit "No programs specified"
 fi
 
 log_action "Programs to deploy: ${PROGRAMS[*]}"
-log_info "Selected cluster: $CLUSTER"
-log_info "Selected provider: $PROVIDER_URL"
 
-# ---------------------------------------------------------------------------- #
-#                              BUILD AND DEPLOY                                #
-# ---------------------------------------------------------------------------- #
-
-# Validate programs are supported
+# Assert that the specified programs are valid
 for program in "${PROGRAMS[@]}"; do
     if [[ ! " ${VALID_PROGRAMS[*]} " =~ " ${program} " ]]; then
         show_usage_and_exit "Program '$program' is not supported. Supported programs: ${VALID_PROGRAMS[*]}"
     fi
     log_success "Program '$program' is valid"
 done
+
+# ---------------------------------------------------------------------------- #
+#                              BUILD AND DEPLOY                                #
+# ---------------------------------------------------------------------------- #
 
 # Generate new program keypairs (unless --keep-keypairs is set)
 for program in "${PROGRAMS[@]}"; do
@@ -193,20 +190,24 @@ done
 # Start Colima (if it's already running, the command is being ignored automatically)
 colima start
 
-# Build and deploy programs
+# Sync the program ids
+anchor keys sync
+
+# Build the programs
 for program in "${PROGRAMS[@]}"; do
     echo "🔨 Building $program..."
     anchor build -v -p "$program"
 done
 
+# Deploy the programs
 for program in "${PROGRAMS[@]}"; do
-    echo "🚀 Deploying $program to $CLUSTER..."
-    ANCHOR_PROVIDER_URL=$PROVIDER_URL anchor deploy -v -p "$program" --provider.cluster $CLUSTER
+    echo "🚀 Deploying $program"
+    anchor deploy -v -p "$program" --provider.cluster $CLUSTER
 done
 
 # Closes the associated buffer accounts, if any (in order to recover the rent SOL from them)
-log_info "Closing existing buffer accounts on $CLUSTER..."
-ANCHOR_PROVIDER_URL=$PROVIDER_URL solana program close --buffers -u "$CLUSTER"
+log_info "Closing any hanging buffer accounts"
+solana program close --buffers
 
 echo "🎉 Deployment completed for programs: ${PROGRAMS[*]}"
 
@@ -216,7 +217,6 @@ echo "🎉 Deployment completed for programs: ${PROGRAMS[*]}"
 
 for program in "${PROGRAMS[@]}"; do
     if [[ -n "${INIT_SCRIPTS[$program]}" ]]; then
-        ANCHOR_PROVIDER_URL=$PROVIDER_URL \
         ANCHOR_WALLET=~/.config/solana/id.json \
         na vitest --run --mode scripts "${INIT_SCRIPTS[$program]}"
     else
@@ -232,7 +232,6 @@ done
 log_info "Switching to main branch and pulling latest changes..."
 git switch main
 git pull
-anchor keys sync
 
 DEPLOYMENT_BRANCH="chore/deployment"
 

--- a/scripts/bash/deploy-programs.sh
+++ b/scripts/bash/deploy-programs.sh
@@ -82,15 +82,13 @@ MAINNET_FLAG=false
 PROGRAMS=()
 VALID_PROGRAMS=("sablier_lockup" "sablier_merkle_instant")
 
-CLUSTER="devnet"
-ANCHOR_PROVIDER_URL="https://api.devnet.solana.com"
+CLUSTER=""
+export ANCHOR_PROVIDER_URL=""
 
-# The init scripts mappings
+# Declare the init scripts mapping
 declare -A INIT_SCRIPTS
-INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup-and-create-streams.ts"
-INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant-and-create-campaign.ts"
 
-# Program configuration mappings
+# Define the program configuration mapping
 declare -A PROGRAM_CONFIG
 PROGRAM_CONFIG["sablier_lockup"]="programs/lockup/src/lib.rs"
 PROGRAM_CONFIG["sablier_merkle_instant"]="programs/merkle_instant/src/lib.rs"
@@ -136,9 +134,15 @@ if [[ "$MAINNET_FLAG" == true ]]; then
     CLUSTER="mainnet"
     ANCHOR_PROVIDER_URL="https://api.mainnet-beta.solana.com"
 
-    # We don't want to create demo streams/campaigns on mainnet
+    # Note: we don't want to create demo streams/campaigns on mainnet
     INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup.ts"
     INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant.ts"
+else
+    CLUSTER="devnet"
+    ANCHOR_PROVIDER_URL="https://api.devnet.solana.com"
+
+    INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup-and-create-streams.ts"
+    INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant-and-create-campaign.ts"
 fi
 
 # Configure Solana CLI to use the correct provider

--- a/scripts/bash/deploy-programs.sh
+++ b/scripts/bash/deploy-programs.sh
@@ -82,8 +82,8 @@ MAINNET_FLAG=false
 PROGRAMS=()
 VALID_PROGRAMS=("sablier_lockup" "sablier_merkle_instant")
 
-CLUSTER=""
-export ANCHOR_PROVIDER_URL=""
+CLUSTER="devnet"
+ANCHOR_PROVIDER_URL="https://api.devnet.solana.com"
 
 # The init scripts mappings
 declare -A INIT_SCRIPTS
@@ -139,9 +139,6 @@ if [[ "$MAINNET_FLAG" == true ]]; then
     # We don't want to create demo streams/campaigns on mainnet
     INIT_SCRIPTS["sablier_lockup"]="scripts/ts/init-lockup.ts"
     INIT_SCRIPTS["sablier_merkle_instant"]="scripts/ts/init-merkle-instant.ts"
-else
-    CLUSTER="devnet"
-    ANCHOR_PROVIDER_URL="https://api.devnet.solana.com"
 fi
 
 # Configure Solana CLI to use the correct provider


### PR DESCRIPTION
scripts: use global ANCHOR_PROVIDER_URL
scripts: solana cmds w/o ANCHOR_ var prefixes
scripts: sync anchor keys before building

scripts: refactor

Notes:

- I've tested the deployment to Devnet with `$HOME/.config/solana/cli/config.yml` set to Mainnet - and it worked successfully.
- Instead of editing the `$HOME/.config/solana/cli/config.yml` file "manually", we're doing this via `solana program set` now.
- Instead of the local `PROVIDER_URL` & global `ANCHOR_PROVIDER_URL`, we only use the latter now.
- The `ANCHOR_` vars shouldn't be passed to the Solana CLI commands, as they do not care about such variables.
- The syncing of the program ids/keys must happen before building for the `lib.rs` to contain the correct id.
- The 2 calls to `log_info()` have been removed, because `solana config set` outputs the respective information, anyways.