### PR TITLE
docs: add explanatory comments to the events

### DIFF
--- a/programs/lockup/src/utils/events.rs
+++ b/programs/lockup/src/utils/events.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 
+/// Emitted when a stream is canceled.
 #[event]
 pub struct CancelLockupStream {
     pub deposited_token_mint: Pubkey,
@@ -9,6 +10,7 @@ pub struct CancelLockupStream {
     pub stream_nft_mint: Pubkey,
 }
 
+/// Emitted when an LL stream is created.
 #[event]
 pub struct CreateLockupLinearStream {
     pub deposit_token_decimals: u8,
@@ -19,6 +21,7 @@ pub struct CreateLockupLinearStream {
     pub stream_nft_mint: Pubkey,
 }
 
+/// Emitted when fees are collected from the treasury.
 #[event]
 pub struct FeesCollected {
     pub fee_amount: u64,
@@ -26,6 +29,7 @@ pub struct FeesCollected {
     pub fee_recipient: Pubkey,
 }
 
+/// Emitted when a sender gives up the right to cancel a stream.
 #[event]
 pub struct RenounceLockupStream {
     pub deposited_token_mint: Pubkey,
@@ -33,6 +37,7 @@ pub struct RenounceLockupStream {
     pub stream_nft_mint: Pubkey,
 }
 
+/// Emitted when tokens are withdrawn from a stream.
 #[event]
 pub struct WithdrawFromLockupStream {
     pub deposited_token_mint: Pubkey,

--- a/programs/merkle_instant/src/utils/events.rs
+++ b/programs/merkle_instant/src/utils/events.rs
@@ -1,5 +1,27 @@
 use anchor_lang::prelude::*;
 
+/// Emitted when an airdrop is claimed on behalf of an eligible recipient.
+#[event]
+pub struct Claim {
+    pub amount: u64,
+    pub campaign: Pubkey,
+    pub claimer: Pubkey,
+    pub claim_receipt: Pubkey,
+    pub fee_in_lamports: u64,
+    pub index: u32,
+    pub recipient: Pubkey,
+}
+
+/// Emitted when the campaign creator claws back the unclaimed tokens.
+#[event]
+pub struct Clawback {
+    pub amount: u64,
+    pub campaign: Pubkey,
+    pub campaign_creator: Pubkey,
+    pub clawback_recipient: Pubkey,
+}
+
+/// Emitted when a Merkle Instant campaign is created.
 #[event]
 pub struct CreateCampaign {
     pub aggregate_amount: u64,
@@ -15,25 +37,7 @@ pub struct CreateCampaign {
     pub token_mint: Pubkey,
 }
 
-#[event]
-pub struct Claim {
-    pub amount: u64,
-    pub campaign: Pubkey,
-    pub claimer: Pubkey,
-    pub claim_receipt: Pubkey,
-    pub fee_in_lamports: u64,
-    pub index: u32,
-    pub recipient: Pubkey,
-}
-
-#[event]
-pub struct Clawback {
-    pub amount: u64,
-    pub campaign: Pubkey,
-    pub campaign_creator: Pubkey,
-    pub clawback_recipient: Pubkey,
-}
-
+/// Emitted when fees are collected from the treasury.
 #[event]
 pub struct FeesCollected {
     pub fee_amount: u64,


### PR DESCRIPTION
motivation: "in sync" with the `docs`  