### PR TITLE
chore: remove solana-program dep from .toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,6 @@ dependencies = [
  "anchor-spl",
  "chainlink_solana",
  "mpl-token-metadata",
- "solana-program",
 ]
 
 [[package]]
@@ -1610,7 +1609,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "chainlink_solana",
- "solana-program",
 ]
 
 [[package]]

--- a/programs/lockup/Cargo.toml
+++ b/programs/lockup/Cargo.toml
@@ -21,4 +21,3 @@
   anchor-spl = { version = "0.31.1", features = ["metadata"] }
   mpl-token-metadata = "5.1.0"
   chainlink_solana = { git = "https://github.com/smartcontractkit/chainlink-solana", branch = "solana-2.1" }
-  solana-program = "=2.1.21"

--- a/programs/merkle_instant/Cargo.toml
+++ b/programs/merkle_instant/Cargo.toml
@@ -20,4 +20,3 @@
   anchor-lang = { version = "0.31.1", features = ["init-if-needed"] }
   anchor-spl = { version = "0.31.1" }
   chainlink_solana = { git = "https://github.com/smartcontractkit/chainlink-solana", branch = "solana-2.1" }
-  solana-program = "=2.1.21"


### PR DESCRIPTION
Closes https://github.com/sablier-labs/solsab/issues/287

Please also verify whether the anchor build does not bump the `solana-program` version to 2.2.1 in the `Cargo.lock` file (this is the reason the configuration was added to the .toml file).
